### PR TITLE
test on 0.4 and 0.5 explicitly on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 matrix:
   allow_failures:


### PR DESCRIPTION
as long as 0.4 is still supported in REQUIRE