### PR TITLE
Remove depwarns in v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5
 PyCall
+Compat 0.18.0

--- a/src/PyAMG.jl
+++ b/src/PyAMG.jl
@@ -9,6 +9,7 @@ export RugeStubenSolver,
 
 
 using PyCall
+using Compat
 
 # @pyimport scipy.sparse as scipy_sparse
 # @pyimport pyamg
@@ -70,8 +71,8 @@ end
 
 type RugeStuben end
 type SmoothedAggregation end
-typealias RugeStubenSolver AMGSolver{RugeStuben}
-typealias SmoothedAggregationSolver AMGSolver{SmoothedAggregation}
+@compat const RugeStubenSolver = AMGSolver{RugeStuben}
+@compat const SmoothedAggregationSolver = AMGSolver{SmoothedAggregation}
 
 
 function set_kwargs!(amg::AMGSolver; kwargs...)


### PR DESCRIPTION
`typealias` has now been deprecated in favour of `const X = Y`